### PR TITLE
Fix internal threat flag not resetting

### DIFF
--- a/app/src/main/java/com/boarbeard/generator/beimax/ThreatsGenerator.kt
+++ b/app/src/main/java/com/boarbeard/generator/beimax/ThreatsGenerator.kt
@@ -156,6 +156,8 @@ class ThreatsGenerator(
                         return emptyArray()
                     }
                     lastThreatWasInternal = true
+                } else {
+                    lastThreatWasInternal = false
                 }
             } else {
                 // add empty group to not have NPEs later on - this is not so elegant and might be subject to refactoring at some time...


### PR DESCRIPTION
There has been a small error in the internal threat flag setting, so there were no missions with more than one internal threats. Fixed thanks to @Parakoos